### PR TITLE
query-update

### DIFF
--- a/mini-project-task-manager/query.sql
+++ b/mini-project-task-manager/query.sql
@@ -26,11 +26,10 @@ CREATE TABLE IF NOT EXISTS `users` (
 
 DROP TABLE IF EXISTS `user_roles`;
 CREATE TABLE IF NOT EXISTS `user_roles` (
-
     id         BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id    BIGINT NOT NULL,
     role       VARCHAR(30) NOT NULL,
-
+    
     CONSTRAINT `fk_user_roles_user_id`
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     CONSTRAINT `uq_user_roles` UNIQUE (user_id, role),
@@ -68,17 +67,17 @@ CREATE TABLE IF NOT EXISTS `tasks`(
 	priority    	VARCHAR(50) NOT NULL DEFAULT 'MEDIUM',
 	due_date    	DATE NOT NULL,
 	created_at  	DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    updated_at  	DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+	updated_at  	DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     
-   CONSTRAINT `chk_tasks_status` CHECK(status IN('TODO','IN_PROGRESS','DONE')),
-   CONSTRAINT `chk_tasks_priority` CHECK(priority IN('LOW','MEDIUM','HIGH')),
-   CONSTRAINT `fk_tasks_project` FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
-   CONSTRAINT `fk_tasks_user` FOREIGN KEY (author_id) REFERENCES users(id),
+	CONSTRAINT `chk_tasks_status` CHECK (status IN ('TODO','IN_PROGRESS','DONE')),
+	CONSTRAINT `chk_tasks_priority` CHECK (priority IN ('LOW','MEDIUM','HIGH')),
+	CONSTRAINT `fk_tasks_project` FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+	CONSTRAINT `fk_tasks_user` FOREIGN KEY (author_id) REFERENCES users(id),
 
-   INDEX idx_tasks_project_status (project_id, status),
-   INDEX idx_tasks_author_due (author_id, due_date)   
+	INDEX idx_tasks_project_status (project_id, status),
+	INDEX idx_tasks_author_due (author_id, due_date)   
 
-) ENGINE=InnoDB
+) 	ENGINE=InnoDB
     DEFAULT CHARSET = utf8mb4
     COLLATE = utf8mb4_unicode_ci
     COMMENT = '할일';
@@ -113,7 +112,7 @@ CREATE TABLE IF NOT EXISTS `comments` (
     task_id      	BIGINT NOT NULL,
     author_id    	BIGINT NOT NULL,
     content      	TEXT NOT NULL,
-    created_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_at   	DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     CONSTRAINT `fk_comments_task` FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
     CONSTRAINT `fk_comments_author` FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
 
@@ -129,11 +128,11 @@ CREATE TABLE IF NOT EXISTS `notifications` (
     author_id    	BIGINT NOT NULL,
     title      		VARCHAR(300) NOT NULL,
     content    		TEXT NOT NULL,
-    created_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_at   	DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     CONSTRAINT `fk_notis_project` FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
     CONSTRAINT `fk_notis_author` FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
 
-) ENGINE=InnoDB
+) 	ENGINE=InnoDB
     DEFAULT CHARSET = utf8mb4
     COLLATE = utf8mb4_unicode_ci
     COMMENT = '공지';


### PR DESCRIPTION
쿼리 가독성 정렬